### PR TITLE
Update the Cloudwatch Logs proposal

### DIFF
--- a/docs/rfc/application_logging/logging_to_cloudwatch_logs.md
+++ b/docs/rfc/application_logging/logging_to_cloudwatch_logs.md
@@ -42,9 +42,10 @@ It should define the following resources:
 - A [CloudWatch LogGroup](https://www.pulumi.com/registry/packages/aws/api-docs/cloudwatch/loggroup/) for the
   environment. In implementation, keeping with AWS's log group naming conventions, this might be called something like
   `/tb/mailstrom/stage` for the Mailstrom/Stalwart staging environment.
-- A [CloudWatch LogStream](https://www.pulumi.com/registry/packages/aws/api-docs/cloudwatch/logstream/) for each
-  application. This is somewhat arbitrary and can be broken up however it makes sense. (i.e.  `stalwart/mail` vs
-  `stalwart/management-api`)
+- An optional [CloudWatch LogStream](https://www.pulumi.com/registry/packages/aws/api-docs/cloudwatch/logstream/) for
+  any applications which can't be configured (or we don't want to configure) to create a log stream on their own. This
+  is somewhat arbitrary and can be broken up however it makes sense. For example, by service: `stalwart/mail` vs
+  `stalwart/management-api`. Or one log stream per server node: `stalwart/node-001` vs `stalwart/node-050`.
 - A set of [IAM Policies](https://www.pulumi.com/registry/packages/aws/api-docs/iam/policy/) allowing various levels of
   access to these streams. Applications will need a write access policy. Users will need read access policies. There
   should be a level of customization here, allowing the engineers to design access in ways that make sense for their

--- a/docs/rfc/application_logging/logging_to_cloudwatch_logs.md
+++ b/docs/rfc/application_logging/logging_to_cloudwatch_logs.md
@@ -43,8 +43,8 @@ It should define the following resources:
   environment. In implementation, keeping with AWS's log group naming conventions, this might be called something like
   `/tb/mailstrom/stage` for the Mailstrom/Stalwart staging environment.
 - A [CloudWatch LogStream](https://www.pulumi.com/registry/packages/aws/api-docs/cloudwatch/logstream/) for each
-  application. This is somewhat arbitrary and can be broken up however it makes sense. (i.e.
-  `/tb/mailstrom/stage/stalwart/mail` vs `/tb/mailstrom/stage/stalwart/management-api`)
+  application. This is somewhat arbitrary and can be broken up however it makes sense. (i.e.  `stalwart/mail` vs
+  `stalwart/management-api`)
 - A set of [IAM Policies](https://www.pulumi.com/registry/packages/aws/api-docs/iam/policy/) allowing various levels of
   access to these streams. Applications will need a write access policy. Users will need read access policies. There
   should be a level of customization here, allowing the engineers to design access in ways that make sense for their


### PR DESCRIPTION
I did a slightly deeper dive into our use cases and made a couple slight adjustments to the CloudWatch Logs proposal. A few facts that led to these adjustments:

- Fargate services that log to CloudWatch automatically use the container ID as part of the log stream name, and you *must* use the `awslogs-stream-prefix` option when defining the [Fargate LogConfiguration](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html). There is no way to configure this to use pre-created log streams.
- Stalwart servers (prior to the move to Fargate containers) will use a local installation of fluent-bit to [forward the logs to CloudWatch](https://docs.fluentbit.io/manual/data-pipeline/outputs/cloudwatch). That plugin allows for both kinds of configuration, one where you specify a log stream as well as one where you specify a prefix.
- Log groups and log streams are both organizational units of sorts, and we can be a lot more terse in our naming than what I originally wrote up.